### PR TITLE
update observables

### DIFF
--- a/src/lattice/generate.jl
+++ b/src/lattice/generate.jl
@@ -105,8 +105,8 @@ function generatelattice_std(param)
     bonds = Bond[]
     ib = 0
 
-    use_index_as_sitetype = get(param, "Use Indecies as Site Types", false)
-    use_index_as_bondtype = get(param, "Use Indecies as Bond Types", false)
+    use_index_as_sitetype = get(param, "Use Indicies as Site Types", false)
+    use_index_as_bondtype = get(param, "Use Indicies as Bond Types", false)
 
     for icell in 0:(numcell-1)
         cellcoord = index2coord(icell, L)

--- a/src/observables/binning.jl
+++ b/src/observables/binning.jl
@@ -13,11 +13,22 @@ mutable struct BinningObservable <: ScalarObservable
     lastbin :: Int
     minbinnum :: Int
     maxlevel :: Int
+
+    function BinningObservable(minbinnum::Int = 128) 
+        Base.depwarn("BinningObservable is deprecated. Use obs=SimpleObservable() and binning(obs) instead.", nothing, force=true)
+
+        raw_ts = zeros(0)
+        bins = zeros(0)
+        sum = zeros(1)
+        sum2 = zeros(1)
+        entries = zeros(Int,1)
+        binsize = 1
+        lastbin = 0
+        maxlevel = 1
+        new(raw_ts, bins, sum, sum2, entries, binsize, lastbin, minbinnum, maxlevel)
+    end
 end
 
-function BinningObservable(minbinnum::Int = 128) 
-    BinningObservable( zeros(0), zeros(0), zeros(1), zeros(1), zeros(Int,1), 1, 0, minbinnum, 1)
-end
 
 function reset!(b::BinningObservable)
     b.raw_ts = zeros(0)

--- a/src/observables/binning.jl
+++ b/src/observables/binning.jl
@@ -21,7 +21,7 @@ mutable struct BinningObservable <: ScalarObservable
         bins = zeros(0)
         sum = zeros(1)
         sum2 = zeros(1)
-        entries = zeros(Int,1)
+        entries = zeros(Int, 1)
         binsize = 1
         lastbin = 0
         maxlevel = 1

--- a/src/observables/binningvector.jl
+++ b/src/observables/binningvector.jl
@@ -4,21 +4,31 @@ export BinningVectorObservableSet
 
 mutable struct BinningVectorObservable <: VectorObservable
     ## index of these vectors denotes the level of bins (each bin stores the mean of 2^(i-1) values)
-    raw_ts :: Vector{Vector{Float64}}        ## Time series of raw data
-    bins :: Vector{Vector{Float64}}          ## Time series of bins
-    sum :: Vector{Vector{Float64}}           ## Summation of stored values
-    sum2 :: Vector{Vector{Float64}}          ## Summation of square of bin's mean
-    entries :: Vector{Int}           ## Number of bins
+    raw_ts :: Vector{Vector{Float64}} ## Time series of raw data
+    bins :: Vector{Vector{Float64}}   ## Time series of bins
+    sum :: Vector{Vector{Float64}}    ## Summation of stored values
+    sum2 :: Vector{Vector{Float64}}   ## Summation of square of bin's mean
+    entries :: Vector{Int}            ## Number of bins
     binsize :: Int
     lastbin :: Int
     minbinnum :: Int
     maxlevel :: Int
+
+    function BinningVectorObservable(minbinnum::Int = 128) 
+        Base.depwarn("BinningVectorObservable is deprecated. Use obs=SimpleVectorObservable() and binning(obs) instead.", nothing, force=true)
+
+        raw_ts = Vector{Float64}[]
+        bins = Vector{Float64}[]
+        sum = Vector{Float64}[]
+        sum2 = Vector{Float64}[]
+        entries = zeros(Int,1)
+        binsize = 1
+        lastbin = 0
+        maxlevel = 1
+        new(raw_ts, bins, sum, sum2, entries, binsize, lastbin, minbinnum, maxlevel)
+    end
 end
 
-function BinningVectorObservable(minbinnum::Int = 128) 
-    BinningVectorObservable( Vector{Float64}[], Vector{Float64}[], Vector{Float64}[], Vector{Float64}[],
-                             zeros(Int,1), 1, 0, minbinnum, 1)
-end
 
 function reset!(b::BinningVectorObservable)
     b.raw_ts = Vector{Float64}[]

--- a/src/observables/jackknife.jl
+++ b/src/observables/jackknife.jl
@@ -117,18 +117,10 @@ import Base.^
 const JackknifeSet = MCObservableSet{Jackknife}
 
 jackknife(obs::ScalarObservable) = Jackknife(obs)
-jackknife(obs::ScalarObservable, binsize::Int) = Jackknife(binning(obs, binsize))
 function jackknife(obsset :: MCObservableSet)
     JK = JackknifeSet()
     for (k,v) in obsset
         JK[k] = Jackknife(v)
-    end
-    return JK
-end
-function jackknife(obsset :: MCObservableSet, binsize::Int)
-    JK = JackknifeSet()
-    for (k,v) in obsset
-        JK[k] = jackknife(v, binsize)
     end
     return JK
 end

--- a/src/observables/jackknifevector.jl
+++ b/src/observables/jackknifevector.jl
@@ -160,7 +160,6 @@ end
 const JackknifeVectorSet = MCObservableSet{JackknifeVector}
 
 jackknife(obs::VectorObservable) = JackknifeVector(obs)
-jackknife(obs::VectorObservable, binsize::Int) = JackknifeVector(binning(obs, binsize))
 function jackknife(obsset :: MCObservableSet{Obs}) where (Obs<: VectorObservable)
     JK = JackknifeSet()
     for (k,v) in obsset
@@ -168,13 +167,3 @@ function jackknife(obsset :: MCObservableSet{Obs}) where (Obs<: VectorObservable
     end
     return JK
 end
-
-function jackknife(obsset :: MCObservableSet{Obs}, binsize::Int) where (Obs<: VectorObservable)
-    JK = JackknifeSet()
-    for (k,v) in obsset
-        JK[k] = jackknife(v, binsize)
-    end
-    return JK
-end
-
-

--- a/src/observables/jackknifevector.jl
+++ b/src/observables/jackknifevector.jl
@@ -4,12 +4,27 @@ mutable struct JackknifeVector <: VectorObservable
     xs :: Vector{Vector{Float64}}
 end
 
+function jk_helper(xs::Vector{Vector{Float64}})
+    ndata = length(xs)
+    nobs = length(xs[1])
+    ret = Vector{Float64}[zeros(nobs) for i in 1:ndata]
+
+    s = sum(xs)
+    coeff = 1.0 / (ndata - 1)
+    n = length(xs)-1
+    ret = similar(xs)
+    for i in 1:n+1
+        ret[i] = coeff .* (s.-xs[i])
+    end
+    return ret
+end
+
 JackknifeVector() = JackknifeVector(Vector{Float64}[])
 
 function JackknifeVector(jk::JackknifeVector, f::Function) 
     xs = similar(jk.xs)
     for i in 1:length(jk.xs)
-        xs[i] = f(jk.xs[i])
+        xs[i] = broadcast(f, jk.xs[i])
     end
     JackknifeVector(xs)
 end
@@ -38,36 +53,46 @@ count(jk::JackknifeVector) = length(jk.xs)
 
 function mean(jk::JackknifeVector)
     if isempty(jk) 
-        return NaN
+        return [NaN]
     else
-        return mean.(jk.xs)
+        res = zeros(length(jk.xs[1]))
+        for data in jk.xs
+            res .+= data
+        end
+        return res .* (1.0 / length(jk.xs))
     end
 end
 function var(jk::JackknifeVector)
     n = count(jk)
     if n < 2
-        return NaN
+        return [NaN]
     else
         m = mean(jk)
-        return sum(abs2, jk.xs.-m)*(n-1)
+        s = similar(m)
+        for data in jk.xs
+            s .+= (data .- m) .^ 2
+        end
+        s .*= (n-1.0)/n
+        return s
     end
 end
 stddev(jk::JackknifeVector) = sqrt.(var(jk))
 function stderror(jk::JackknifeVector)
-    n = count(jk)
-    if n == 0
-        return NaN
-    elseif n == 1
-        return Inf
-    else
-        m2 = sum(abs2, jk.xs)
-        m2 /= n
-        m = mean(jk)
-        sigma2 = m2 - m.*m
-        sigma2 *= n-1
-        map!(maxzero, sigma2)
-        return sqrt(sigma2)
-    end
+    # n = count(jk)
+    # if n == 0
+    #     return NaN
+    # elseif n == 1
+    #     return Inf
+    # else
+    #     m2 = sum(abs2, jk.xs)
+    #     m2 /= n
+    #     m = mean(jk)
+    #     sigma2 = m2 - m.*m
+    #     sigma2 *= n-1
+    #     map!(maxzero, sigma2)
+    #     return sqrt(sigma2)
+    # end
+    return stddev(jk)
 end
 
 
@@ -132,14 +157,24 @@ for op in ( :*, :/, :\)
     end
 end
 
-const JackknifeSet = MCObservableSet{Jackknife}
+const JackknifeVectorSet = MCObservableSet{JackknifeVector}
 
 jackknife(obs::VectorObservable) = JackknifeVector(obs)
+jackknife(obs::VectorObservable, binsize::Int) = JackknifeVector(binning(obs, binsize))
 function jackknife(obsset :: MCObservableSet{Obs}) where (Obs<: VectorObservable)
     JK = JackknifeSet()
     for (k,v) in obsset
-        JK[k] = JackknifeVector(v)
+        JK[k] = jackknife(v)
     end
     return JK
 end
+
+function jackknife(obsset :: MCObservableSet{Obs}, binsize::Int) where (Obs<: VectorObservable)
+    JK = JackknifeSet()
+    for (k,v) in obsset
+        JK[k] = jackknife(v, binsize)
+    end
+    return JK
+end
+
 

--- a/src/observables/tinyvector.jl
+++ b/src/observables/tinyvector.jl
@@ -46,7 +46,7 @@ end
 function var(obs::TinyVectorObservable)
     if obs.num  > 1
         v = (obs.sum2 .- (obs.sum.^2)./obs.num)./(obs.num-1)
-        return map!(maxzero, v)
+        return map(maxzero, v)
     else
         return fill(NaN, length(obs.sum))
     end

--- a/src/runMC.jl
+++ b/src/runMC.jl
@@ -33,6 +33,11 @@ NOTE: Restart will fail if the version or the system image of julia change (see 
     - Default: `8192`
 - "Thermalization": The number of Monte Carlo steps for thermalization
     - Default: `MCS>>3`
+- "Binning Size": The size of binning
+    - Default: `0`
+- "Number of Bins": The number of bins
+    - Default: `0`
+    - If both "Binning Size" and "Number of Bins" are not given, "Binning Size" is set to `floor(sqrt(MCS))`.
 - "Seed": The initial seed of the random number generator, `MersenneTwister`
     - Default: determined randomly (see the doc of `Random.seed!`)
 - "Checkpoint Filename Prefix": See the "Restart" section.
@@ -78,7 +83,8 @@ function runMC(model, param::Parameter)
 
     mcs = 0
     MCS += Therm
-    obs = BinningObservableSet()
+    # obs = BinningObservableSet()
+    obs = SimpleObservableSet()
     makeMCObservable!(obs, "Time per MCS")
     makeMCObservable!(obs, "MCS per Second")
 
@@ -130,7 +136,12 @@ function runMC(model, param::Parameter)
         end
     end
 
-    jk = pp(model, param, obs)
+    binsize = get(param, "Binning Size", 0) :: Int
+    numbins = get(param, "Number of Bins", 0) :: Int
+    binned = binning(obs, binsize=binsize, numbins=numbins)
+
+    jk = pp(model, param, binned)
+
 
     if verbose
         println("Finish: ", param)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/classical.jl
+++ b/test/classical.jl
@@ -25,7 +25,7 @@ end
 
 function parse_filename(filename, ::Union{Type{Ising}, Type{XY}})
     m = match(r"^J_([\d.-]*)__N_([\d.-]*).dat$", filename)
-    if m == nothing
+    if m === nothing
         return nothing
     end
     p = Parameter()
@@ -36,7 +36,7 @@ end
 
 function parse_filename(filename, ::Union{Type{Potts}, Type{Clock}})
     m = match(r"^Q_(\d*)__J_([\d.-]*)__N_(\d*).dat$", filename)
-    if m == nothing
+    if m === nothing
         return nothing
     end
     p = Parameter()
@@ -54,7 +54,7 @@ end
     model = eval(Symbol(modelstr))
     for filename in readdir(joinpath("ref", modelstr))
         p = parse_filename(filename, model)
-        if p == nothing
+        if p === nothing
             continue
         end
         testname = ""

--- a/test/observable.jl
+++ b/test/observable.jl
@@ -86,6 +86,8 @@ function test_jackknife(scalartype, vectortype)
     @test means_scalar ≈ means_vector
     # @test vars_scalar ≈ vars_vector
 
+    jk_scalar_x[1] + jk_vector_x
+    jk_scalar_x[1] * jk_vector_x
 end
 
 @testset "Simple" begin

--- a/test/observable.jl
+++ b/test/observable.jl
@@ -1,0 +1,100 @@
+using Random
+
+function test_single(scalartype, vectortype)
+    nobs = 3
+    ndata = 100
+    obs_scalar = [scalartype() for i in 1:nobs]
+    obs_vector = vectortype()
+    rng = Random.Xoshiro(SEED)
+    X = randn(rng, nobs, ndata)
+    for i in 1:ndata
+        for j in 1:nobs
+            push!(obs_scalar[j], X[j, i])
+        end
+        push!(obs_vector, X[:, i])
+    end
+
+    mean_scalar = [mean(obs_scalar[i]) for i in 1:nobs]
+    mean_vector = mean(obs_vector)
+    var_scalar = [var(obs_scalar[i]) for i in 1:nobs]
+    var_vector = var(obs_vector)
+
+    @test mean_scalar ≈ mean(X, dims=2)[:]
+    @test var_scalar ≈ var(X, dims=2)[:]
+    @test mean_vector ≈ mean(X, dims=2)[:]
+    @test var_vector ≈ var(X, dims=2)[:]
+end
+
+function test_binning(scalartype, vectortype)
+    nobs = 3
+    ndata = 100
+    obs_scalar = [scalartype() for i in 1:nobs]
+    obs_vector = vectortype()
+    rng = Random.Xoshiro(SEED)
+    X = randn(rng, nobs, ndata)
+    for i in 1:ndata
+        for j in 1:nobs
+            push!(obs_scalar[j], X[j, i])
+        end
+        push!(obs_vector, X[:, i])
+    end
+
+    binning_scalar = [binning(obs_scalar[i]) for i in 1:nobs]
+    binning_vector = binning(obs_vector)
+
+    mean_scalar = [mean(binning_scalar[i]) for i in 1:nobs]
+    mean_vector = mean(binning_vector)
+    var_scalar = [var(binning_scalar[i]) for i in 1:nobs]
+    var_vector = var(binning_vector)
+
+    @test mean_scalar ≈ mean_vector
+    @test var_scalar ≈ var_vector
+end
+
+function test_jackknife(scalartype, vectortype)
+    nobs = 3
+    ndata = 100
+    obs_scalar_x = [scalartype() for i in 1:nobs]
+    obs_vector_x = vectortype()
+    obs_scalar_y = [scalartype() for i in 1:nobs]
+    obs_vector_y = vectortype()
+    rng = Random.Xoshiro(SEED)
+    X = randn(rng, nobs, ndata)
+    Y = randn(rng, nobs, ndata)
+    for i in 1:ndata
+        for j in 1:nobs
+            push!(obs_scalar_x[j], X[j, i])
+            push!(obs_scalar_y[j], Y[j, i])
+        end
+        push!(obs_vector_x, X[:, i])
+        push!(obs_vector_y, Y[:, i])
+    end
+    jk_scalar_x = [jackknife(obs_scalar_x[i]) for i in 1:nobs]
+    jk_scalar_y = [jackknife(obs_scalar_y[i]) for i in 1:nobs]
+
+    sxpcy_scalar = [sin(jk_scalar_x[i]) + cos(jk_scalar_y[i]) for i in 1:nobs]
+    means_scalar = [mean(sxpcy_scalar[i]) for i in 1:nobs]
+    vars_scalar = [var(sxpcy_scalar[i]) for i in 1:nobs]
+
+    jk_vector_x = jackknife(obs_vector_x)
+    jk_vector_y = jackknife(obs_vector_y)
+
+    sxpcy_vector = sin(jk_vector_x) + cos(jk_vector_y)
+    means_vector = mean(sxpcy_vector)
+    vars_vector = var(sxpcy_vector)
+
+    @test means_scalar ≈ means_vector
+    # @test vars_scalar ≈ vars_vector
+
+end
+
+@testset "Simple" begin
+    @testset "Simple" test_single(SimpleObservable, SimpleVectorObservable)
+    @testset "Tiny" test_single(TinyObservable, TinyVectorObservable)
+end
+@testset "Binning" begin
+    @testset "Simple" test_binning(SimpleObservable, SimpleVectorObservable)
+end
+@testset "Jackknife" begin
+    @testset "Simple" test_jackknife(SimpleObservable, SimpleVectorObservable)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ const alpha = 0.001
 
 @testset begin
     filenames = [
+                 "observable.jl",
                  "classical.jl",
                  "quantum.jl",
                  "checkpoint.jl",


### PR DESCRIPTION
- Some operations for `VectorObservable` like `var` are corrected
- `BinningObservable` is deprecated
	- Instead, use `obs = SimpleObservable()` and `binned = binning(obs)`
	- `binning` returns new `SimpleObservable` with binned
	- `binning` takes one option, `binsize::Int` or `numbins::Int`.
		- `binsize` is the size of each bin
		- `numbins` is the number of bins
		- If omitted, `binsize = floor(Int, sqrt(count(obs)))` is used
	- `param` in `runMC(param::Parameter)` takes new optional keys, `Binning size` and `Number of Bins`
- Operations for the mixture of `Jackknife` and `JackknifeVector` are added