### PR TITLE
Fix union-find weight updates

### DIFF
--- a/src/model/common/union_find.jl
+++ b/src/model/common/union_find.jl
@@ -56,7 +56,7 @@ const root! = root_path_halving!
 @doc doc"""
     unify!(u, n1, n2)
 
-Connects `n1` and `n2` nodes and returns the root.
+Connects `n1` and `n2` nodes using union by weight and returns the root.
 """
 function unify!(u::UnionFind, n1::Integer, n2::Integer)
     r1 = root!(u, n1)
@@ -67,7 +67,7 @@ function unify!(u::UnionFind, n1::Integer, n2::Integer)
             r1, r2 = r2, r1
         end
         u.parents[r2] = r1
-        u.weights[r2] += u.weights[r1]
+        u.weights[r1] += u.weights[r2]
     end
     return r1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,8 @@ const alpha = 0.001
     filenames = ["observable.jl",
                  "classical.jl",
                  "quantum.jl",
-                 "checkpoint.jl"]
+                 "checkpoint.jl",
+                 "union_find.jl"]
     for filename in filenames
         t = @elapsed include(filename)
         println("$(filename): $t sec")

--- a/test/union_find.jl
+++ b/test/union_find.jl
@@ -1,0 +1,23 @@
+using Test
+using SpinMonteCarlo
+
+@testset "unify!" begin
+    uf = UnionFind(0)
+    addnode!(uf)  # node 1
+    addnode!(uf)  # node 2
+    addnode!(uf)  # node 3
+    addnode!(uf)  # node 4
+
+    # merge two pairs
+    r12 = unify!(uf, 1, 2)
+    r34 = unify!(uf, 3, 4)
+    @test uf.weights[r12] == 2
+    @test uf.weights[r34] == 2
+    @test uf.nclusters == 2
+
+    # merge the resulting sets
+    r = unify!(uf, 1, 3)
+    @test r == SpinMonteCarlo.root!(uf, 2) == SpinMonteCarlo.root!(uf, 4)
+    @test uf.weights[r] == 4
+    @test uf.nclusters == 1
+end


### PR DESCRIPTION
## Summary
- clarify union by weight in `unify!` docs
- merge weights into the new root when unifying
- add regression test for `unify!`

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'`

------
https://chatgpt.com/codex/tasks/task_e_684fa53e5fb883278235b3af6fdb0bb9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the behavior of the union operation in the UnionFind structure to specify union by weight.
- **Bug Fixes**
  - Corrected the logic for updating weights during union operations to ensure accurate cluster management.
- **Tests**
  - Added comprehensive tests for the UnionFind functionality, verifying union operations, root identification, cluster counting, and weight tracking.
  - Included the new tests in the automated test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->